### PR TITLE
Fix Python documentation: there is no package on PyPI

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -19,6 +19,9 @@ code directly into yours.
 To install the library locally, e.g. for working from the command line, you can use
 ```bash
 python setup.py install
+```
+or
+```bash
 pip install -e .
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -12,8 +12,14 @@ coordinate triples. It achieves that by:
 
 ## Install
 
-```python
-pip install flexpolyline
+[FlexPolyline](https://github.com/heremaps/flexible-polyline) is meant to be a reference implementation,
+not a library. Due to that, the best way to include FlexPolyline into your code is to copy the source 
+code directly into yours. 
+
+To install the library locally, e.g. for working from the command line, you can use
+```bash
+python setup.py install
+pip install -e .
 ```
 
 ## Usage


### PR DESCRIPTION
Temporary fix to https://github.com/heremaps/flexible-polyline/issues/8 - documentation no longer claims the Python module is installable via `pip install flexpolyline`.