### PR TITLE
Dart: Compare fields in operator==

### DIFF
--- a/dart/lib/latlngz.dart
+++ b/dart/lib/latlngz.dart
@@ -10,7 +10,8 @@ class LatLngZ {
   String toString() => "LatLngZ [lat=$lat, lng=$lng, z=$z]";
 
   @override
-  bool operator ==(other) => hashCode == other.hashCode;
+  bool operator ==(other) =>
+      other is LatLngZ && other.lat == lat && other.lng == lng && other.z == z;
 
   @override
   int get hashCode => lat.hashCode + lng.hashCode + z.hashCode;


### PR DESCRIPTION
Current implementation of `==` for `LatLngZ` compares only hashes of objects. Hence considers `LatLngZ(1, 2)` and `LatLngZ(2, 1)` to be equal. Proposed implementation compares each field.