### PR TITLE
Add php implementation

### DIFF
--- a/php/.gitattributes
+++ b/php/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.editorconfig               export-ignore
+/.gitattributes              export-ignore
+/.gitignore                  export-ignore
+/.scrutinizer.yml            export-ignore
+/.styleci.yml                export-ignore
+/.travis.yml                 export-ignore
+/PULL_REQUEST_TEMPLATE.md    export-ignore
+/ISSUE_TEMPLATE.md           export-ignore
+/phpcs.xml.dist              export-ignore
+/phpunit.xml.dist            export-ignore
+/tests                       export-ignore
+/docs                        export-ignore

--- a/php/.gitignore
+++ b/php/.gitignore
@@ -1,0 +1,6 @@
+build
+composer.lock
+vendor
+phpcs.xml
+phpunit.xml
+.phpunit.result.cache

--- a/php/.travis.yml
+++ b/php/.travis.yml
@@ -1,0 +1,32 @@
+dist: trusty
+language: php
+
+php:
+  - 7.2
+  - 7.3
+  - 7.4
+  - hhvm
+
+## Cache composer
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  include:
+    - php: 7.2
+      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+
+before_script:
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
+
+script:
+  - vendor/bin/phpcs --standard=psr2 src/
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+
+after_script:
+  - |
+    if [[ "$TRAVIS_PHP_VERSION" != 'hhvm' ]]; then
+      wget https://scrutinizer-ci.com/ocular.phar
+      php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+    fi

--- a/php/.travis.yml
+++ b/php/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - hhvm
 
 ## Cache composer
 cache:
@@ -22,7 +21,6 @@ before_script:
 
 script:
   - vendor/bin/phpcs --standard=psr2 src/
-  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - |

--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,55 @@
+## Testing
+
+```
+composer test
+```
+
+## Usage
+
+### Decode
+
+FlexiblePolyline::decode(string $encoded): array
+
+```
+$data = FlexiblePolyline::decode('BlBoz5xJ67i1BU1B7PUzIhaUxL7YU');
+/** $data:
+[
+    'precision' => 5,
+    'thirdDim' => 2,
+    'thirdDimPrecision' => 0,
+    'polyline' => [
+        [50.10228, 8.69821, 10],
+        [50.10201, 8.69567, 20],
+        [50.10063, 8.6915, 30],
+        [50.09878, 8.68752, 40]
+    ]
+]
+*/
+```
+
+### Encode
+
+FlexiblePolyline::encode(array $coordinates [, int $precision = null, int $thirdDim = null, int $thirdDimPrecision = 0]): string
+
+```
+$encoded = FlexiblePolyline::encode([
+    [50.10228, 8.69821, 10],
+    [50.10201, 8.69567, 20],
+    [50.10063, 8.6915, 30],
+    [50.09878, 8.68752, 40]
+], 5, 2, 0);
+/** $encoded:
+BlBoz5xJ67i1BU1B7PUzIhaUxL7YU
+*/
+```
+
+### Third Dimension
+
+FlexiblePolyline::getThirdDimension(string $encoded): int
+
+```
+$thirdDimension = FlexiblePolyline::getThirdDimension('BVoz5xJ67i1BU')
+/** $thirdDimension:
+1
+*/
+```

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,0 +1,44 @@
+
+{
+    "name": "heremaps/flexible-polyline",
+    "type": "library",
+    "description": "Flexible Polyline encoding: a lossy compressed representation of a list of coordinate pairs or triples",
+    "keywords": [
+        "heremaps",
+        "flexible-polyline"
+    ],
+    "homepage": "https://github.com/heremaps/flexible-polyline",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "rozklad",
+            "email": "jan.rozklad@gmail.com"
+        }
+    ],
+    "require": {
+        "php" : "~7.2",
+        "ext-mbstring": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit" : ">=8.0",
+        "squizlabs/php_codesniffer": "^3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Heremaps\\FlexiblePolyline\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Heremaps\\FlexiblePolyline\\Tests\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "phpunit tests",
+        "check-style": "phpcs src tests",
+        "fix-style": "phpcbf src tests"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/php/src/FlexiblePolyline.php
+++ b/php/src/FlexiblePolyline.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Heremaps\FlexiblePolyline;
+
+use Heremaps\FlexiblePolyline\Traits\DecodableTrait;
+use Heremaps\FlexiblePolyline\Traits\EncodableTrait;
+
+class FlexiblePolyline
+{
+
+    public const FORMAT_VERSION = 1;
+    public const DEFAULT_PRECISION = 5;
+    public const ENCODING_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    public const DECODING_TABLE = [
+        62, -1, -1, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, -1,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+        22, 23, 24, 25, -1, -1, -1, -1, 63, -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+        36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51
+    ];
+
+    public const ABSENT     = 0;
+    public const LEVEL      = 1;
+    public const ALTITUDE   = 2;
+    public const ELEVATION  = 3;
+    public const RESERVED1  = 4;
+    public const RESERVED2  = 5;
+    public const CUSTOM1    = 6;
+    public const CUSTOM2    = 7;
+
+    use DecodableTrait, EncodableTrait;
+}

--- a/php/src/Traits/DecodableTrait.php
+++ b/php/src/Traits/DecodableTrait.php
@@ -113,7 +113,7 @@ trait DecodableTrait
             $charcode = mb_ord($char);
             $decoded = self::DECODING_TABLE[$charcode - 45];
         } catch (Exception $e) {
-            throw new Exception('Char ' . $char . ' could not be decoded charcode: ' . $charcode . ' using index ' . ($charcode - 45));
+            throw new Exception('Char could not be decoded');
         }
 
         return $decoded;

--- a/php/src/Traits/DecodableTrait.php
+++ b/php/src/Traits/DecodableTrait.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Flexible Polyline Decoder
+ *
+ * @package FlexiblePolyline
+ */
+
+namespace Heremaps\FlexiblePolyline\Traits;
+
+use Exception;
+
+trait DecodableTrait
+{
+   
+    public static function decode(string $encoded): array
+    {
+        $decoded = self::decodeUnsignedValues($encoded);
+        $header = self::decodeHeader($decoded[0], $decoded[1]);
+        
+        $factorDegree = 10 ** $header['precision'];
+        $factorZ = 10 ** $header['thirdDimPrecision'];
+        $thirdDim = $header['thirdDim'];
+
+        $lastLat = 0;
+        $lastLng = 0;
+        $lastZ = 0;
+        $res = [];
+    
+        $i = 2;
+        for (; $i < count($decoded);) {
+            $deltaLat = self::toSigned($decoded[$i]) / $factorDegree;
+            $deltaLng = self::toSigned($decoded[$i + 1]) / $factorDegree;
+            $lastLat += $deltaLat;
+            $lastLng += $deltaLng;
+    
+            if ($thirdDim) {
+                $deltaZ = self::toSigned($decoded[$i + 2]) / $factorZ;
+                $lastZ += $deltaZ;
+                $res[] = [$lastLat, $lastLng, $lastZ];
+                $i += 3;
+            } else {
+                $res[] = [$lastLat, $lastLng];
+                $i += 2;
+            }
+        }
+    
+        if ($i !== count($decoded)) {
+            throw new Exception('Invalid encoding. Premature ending reached');
+        }
+    
+        return [
+            'precision' => $header['precision'],
+            'thirdDim' => $header['thirdDim'],
+            'thirdDimPrecision' => $header['thirdDimPrecision'],
+            'polyline' => $res
+        ];
+    }
+
+    public static function decodeHeader(int $version, int $encodedHeader): array
+    {
+        if ($version !== self::FORMAT_VERSION) {
+            throw new Exception('Invalid format version');
+        }
+        $headerNumber = (string)+$encodedHeader;
+        $precision = $headerNumber & 15;
+        $thirdDim = ($headerNumber >> 4) & 7;
+        $thirdDimPrecision = ($headerNumber >> 7) & 15;
+        return compact('precision', 'thirdDim', 'thirdDimPrecision');
+    }
+
+    public static function toSigned(int $val): string
+    {
+        $res = $val;
+        if ($res & 1) {
+            $res = ~$res;
+        }
+        $res >>= 1;
+        return (string)+$res;
+    }
+
+    public static function decodeUnsignedValues(string $encoded): array
+    {
+        $result = 0;
+        $shift = 0;
+        $resList = [];
+
+        $characters = str_split($encoded);
+        
+        foreach ($characters as $char) {
+            $value = self::decodeChar($char);
+            $result |= ($value & 0x1F) << $shift;
+
+            if (($value & 0x20) === 0) {
+                $resList[] = $result;
+                $result = 0;
+                $shift = 0;
+            } else {
+                $shift += 5;
+            }
+        }
+    
+        if ($shift > 0) {
+            throw new Exception('Invalid encoding');
+        }
+        
+        return $resList;
+    }
+
+    public static function decodeChar(string $char): string
+    {
+        try {
+            $charcode = mb_ord($char);
+            $decoded = self::DECODING_TABLE[$charcode - 45];
+        } catch (Exception $e) {
+            throw new Exception('Char ' . $char . ' could not be decoded charcode: ' . $charcode . ' using index ' . ($charcode - 45));
+        }
+
+        return $decoded;
+    }
+
+    public static function getThirdDimension(string $encoded): int
+    {
+        $decoded = self::decodeUnsignedValues($encoded);
+        $header = self::decodeHeader($decoded[0], $decoded[1]);
+        return $header['thirdDim'];
+    }
+}

--- a/php/src/Traits/EncodableTrait.php
+++ b/php/src/Traits/EncodableTrait.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Flexible Polyline Encoder
+ *
+ * @package FlexiblePolyline
+ */
+
+namespace Heremaps\FlexiblePolyline\Traits;
+
+use Exception;
+
+trait EncodableTrait
+{
+    
+    public static function encode(array $coordinates, int $precision = null, int $thirdDim = null, int $thirdDimPrecision = 0): string
+    {
+        if (is_null($precision)) {
+            $precision = self::DEFAULT_PRECISION;
+        }
+
+        $multiplierDegree = 10 ** $precision;
+        $multiplierZ = 10 ** $thirdDimPrecision;
+        $encodedHeaderList = self::encodeHeader($precision, $thirdDim, $thirdDimPrecision);
+        $encodedCoords = [];
+    
+        $lastLat = 0;
+        $lastLng = 0;
+        $lastZ = 0;
+
+        foreach ($coordinates as $location) {
+            $lat = (int)round($location[0] * $multiplierDegree);
+            $encodedCoords[] = self::encodeScaledValue($lat - $lastLat);
+            $lastLat = $lat;
+    
+            $lng = (int)round($location[1] * $multiplierDegree);
+            $encodedCoords[] = self::encodeScaledValue($lng - $lastLng);
+            $lastLng = $lng;
+    
+            if ($thirdDim) {
+                $z = (int)round($location[2] * $multiplierZ);
+                $encodedCoords[] = self::encodeScaledValue($z - $lastZ);
+                $lastZ = $z;
+            }
+        };
+
+        return implode('', array_merge([$encodedHeaderList], $encodedCoords));
+    }
+
+    public static function encodeHeader(int $precision, int $thirdDim, int $thirdDimPrecision): string
+    {
+        if ($precision < 0 || $precision > 15) {
+            throw new Exception('precision out of range. Should be between 0 and 15');
+        }
+        if ($thirdDimPrecision < 0 || $thirdDimPrecision > 15) {
+            throw new Exception('thirdDimPrecision out of range. Should be between 0 and 15');
+        }
+        if ($thirdDim < 0 || $thirdDim > 7 || $thirdDim === 4 || $thirdDim === 5) {
+            throw new Exception('thirdDim should be between 0, 1, 2, 3, 6 or 7');
+        }
+    
+        $res = ($thirdDimPrecision << 7) | ($thirdDim << 4) | $precision;
+        return self::encodeUnsignedNumber(self::FORMAT_VERSION) . self::encodeUnsignedNumber($res);
+    }
+    
+    public static function encodeUnsignedNumber(float $val): string
+    {
+        $res = '';
+        $numVal = (float)$val;
+        while ($numVal > 0x1F) {
+            $pos = ($numVal & 0x1F) | 0x20;
+            $pos = (int)$pos;
+            $res .= self::ENCODING_TABLE[$pos];
+            $numVal >>= 5;
+        }
+        $numVal = (int)$numVal;
+        return $res . self::ENCODING_TABLE[$numVal];
+    }
+
+    public static function encodeScaledValue(float $value): string
+    {
+        $negative = $value < 0;
+        $value <<= 1;
+        if ($negative) {
+            $value = ~$value;
+        }
+    
+        return self::encodeUnsignedNumber($value);
+    }
+}

--- a/php/src/Traits/EncodableTrait.php
+++ b/php/src/Traits/EncodableTrait.php
@@ -13,8 +13,12 @@ use Exception;
 trait EncodableTrait
 {
     
-    public static function encode(array $coordinates, int $precision = null, int $thirdDim = null, int $thirdDimPrecision = 0): string
-    {
+    public static function encode(
+        array $coordinates,
+        int $precision = null,
+        int $thirdDim = null,
+        int $thirdDimPrecision = 0
+    ): string {
         if (is_null($precision)) {
             $precision = self::DEFAULT_PRECISION;
         }

--- a/php/tests/DecoderTest.php
+++ b/php/tests/DecoderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Heremaps\FlexiblePolyline\Tests;
+
+use Heremaps\FlexiblePolyline\FlexiblePolyline;
+use Heremaps\FlexiblePolyline\Tests\FlexiblePolylineTest;
+
+class DecoderTest extends FlexiblePolylineTest
+{
+    public function testLines(): void
+    {
+        $folders = ['round_half_even', 'round_half_up'];
+
+        foreach($folders as $folder) {
+            $this->runFolder($folder);
+        }
+    }
+
+    public function runFolder(string $folder): void
+    {
+        $originalLines = self::getOriginalLines();
+        $encodedLines = self::getEncodedLines($folder);
+        $decodedLines = self::getDecodedLines($folder);
+
+        $results = [];
+
+        for($i = 0; $i < count($encodedLines); $i++)
+        {
+            $input = self::parseLine($originalLines[$i]);
+            $encoded = $encodedLines[$i];
+            $decoded = $decodedLines[$i];
+
+            if ($input['thirdDim'] === 4 || $input['thirdDim'] === 5 || $input['thirdDimPrecision'] > 10 || $input['precision'] > 10) {
+                // Test decoding only
+                $expectedDecoded = self::parseLine($decoded);
+                $decodedEncodedValue = FlexiblePolyline::decode($encoded);
+                $this->assertEqualsCanonicalizing($expectedDecoded, $decodedEncodedValue);
+            } else {
+                // Test full
+                $expectedDecoded = self::parseLine($decoded);
+                $encodedInput = FlexiblePolyline::encode($input['polyline'], $input['precision'], $input['thirdDim'], $input['thirdDimPrecision']);
+                $decodedInput = FlexiblePolyline::decode($encodedInput);
+
+                $this->assertEqualsCanonicalizing($expectedDecoded, $decodedInput);
+            }
+        }
+    }
+
+}

--- a/php/tests/EncoderTest.php
+++ b/php/tests/EncoderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Heremaps\FlexiblePolyline\Tests;
+
+use Heremaps\FlexiblePolyline\FlexiblePolyline;
+use Heremaps\FlexiblePolyline\Tests\FlexiblePolylineTest;
+
+class EncoderTest extends FlexiblePolylineTest
+{
+    public function testLines(): void
+    {
+        $folders = ['round_half_even', 'round_half_up'];
+
+        foreach($folders as $folder) {
+            $this->runFolder($folder);
+        }
+    }
+
+    public function runFolder(string $folder): void
+    {
+        $originalLines = self::getOriginalLines();
+        $encodedLines = self::getEncodedLines($folder);
+
+        $results = [];
+
+        for($i = 0; $i < count($encodedLines); $i++) {
+            $input = self::parseLine($originalLines[$i]);
+            $encodedInput = $encodedLines[$i];
+            
+            if ($input['thirdDim'] === 4 || $input['thirdDim'] === 5 || $input['thirdDimPrecision'] > 10 || $input['precision'] > 10) {
+                continue;
+            }
+
+            $encodedResult = FlexiblePolyline::encode($input['polyline'], $input['precision'], $input['thirdDim'], $input['thirdDimPrecision']);
+            
+            $this->assertEquals($encodedInput, $encodedResult);
+        }
+    }
+
+}

--- a/php/tests/FlexiblePolylineTest.php
+++ b/php/tests/FlexiblePolylineTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Heremaps\FlexiblePolyline\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class FlexiblePolylineTest extends TestCase
+{
+    protected static function getFilepath(string $relativePath): string
+    {
+        return sprintf(__DIR__ . '/../../test/%s', $relativePath);
+    }
+
+    protected static function getOriginalLines(): array
+    {
+        return self::getLinesFromTestFile('original.txt');
+    }
+
+    protected static function getEncodedLines(string $folder = 'round_half_even'): array
+    {
+        return self::getLinesFromTestFile('round_half_even/encoded.txt');
+    }
+
+    protected static function getDecodedLines(string $folder = 'round_half_even'): array
+    {
+        return self::getLinesFromTestFile('round_half_even/decoded.txt');
+    }
+
+    protected static function getLinesFromTestFile(string $filepath): array
+    {
+        return self::getLines(self::getFilepath($filepath));
+    }
+
+    protected static function getLines(string $filepath): array
+    {
+        return array_filter(explode("\n", file_get_contents($filepath)));
+    }
+
+    protected static function parseLine(string $line): array 
+    {
+        list($rawHeader, $rawPolyline) = explode(';', preg_replace('/[ {}\[\]]/', '', $line));
+        list($precision, $thirdDimPrecision, $thirdDim) = array_replace(
+            [0, 0, 0], array_map(
+                function ($value) {
+                    return (int)$value ?: 0;
+                }, explode(',', trim($rawHeader, '()'))
+            )
+        );
+        $polyline = array_map(
+            function ($point) use ($thirdDim) {
+                $coordinates = array_map(
+                    function ($coordinate) { 
+                        return (float)$coordinate ?: null;
+                    }, explode(',', preg_replace('/[()]/', '', $point))
+                );
+                $values = array_map(
+                    function ($coordinate) {
+                        return is_null($coordinate) ? 0 : $coordinate;
+                    }, $coordinates
+                );
+                return array_slice($values, 0, $thirdDim ? 3 : 2);
+            }, explode('),(', $rawPolyline)
+        );
+        return compact('precision', 'thirdDim', 'thirdDimPrecision', 'polyline');
+    }
+}

--- a/php/tests/OtherTest.php
+++ b/php/tests/OtherTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Heremaps\FlexiblePolyline\Tests;
+
+use Heremaps\FlexiblePolyline\FlexiblePolyline;
+use Heremaps\FlexiblePolyline\Tests\FlexiblePolylineTest;
+
+class OtherTest extends FlexiblePolylineTest
+{
+    public function testReadmeExampleDecode(): void
+    {
+        $decoded = FlexiblePolyline::decode('BlBoz5xJ67i1BU1B7PUzIhaUxL7YU');
+
+        $expected = [
+            'precision' => 5,
+            'thirdDim' => 2,
+            'thirdDimPrecision' => 0,
+            'polyline' => [
+                [50.10228, 8.69821, 10],
+                [50.10201, 8.69567, 20],
+                [50.10063, 8.6915, 30],
+                [50.09878, 8.68752, 40]
+            ]
+        ];
+
+        $this->assertEqualsCanonicalizing($expected, $decoded);
+    }
+
+    public function testReadmeExampleEncode(): void
+    {
+        $encoded = FlexiblePolyline::encode(
+            [
+            [50.10228, 8.69821, 10],
+            [50.10201, 8.69567, 20],
+            [50.10063, 8.6915, 30],
+            [50.09878, 8.68752, 40]
+            ], 5, 2, 0
+        );
+
+        $expected = 'BlBoz5xJ67i1BU1B7PUzIhaUxL7YU';
+
+        $this->assertEquals($expected, $encoded);
+    }
+
+    public function testThirdDimension(): void
+    {
+        $this->assertEquals(FlexiblePolyline::getThirdDimension('BFoz5xJ67i1BU'), FlexiblePolyline::ABSENT);
+        $this->assertEquals(FlexiblePolyline::getThirdDimension('BVoz5xJ67i1BU'), FlexiblePolyline::LEVEL);
+        $this->assertEquals(FlexiblePolyline::getThirdDimension('BlBoz5xJ67i1BU'), FlexiblePolyline::ALTITUDE);
+        $this->assertEquals(FlexiblePolyline::getThirdDimension('B1Boz5xJ67i1BU'), FlexiblePolyline::ELEVATION);
+    }
+
+}


### PR DESCRIPTION
### Summary

Adds support to encode/decode flexible polyline in php. It's originally meant to be used as a package, but the code is bunch of static methods organized to class anyway, so in that way it works pretty much the same as the other language implementations.

### Other information

- requires php >=7.2 with mbstring enabled
- usage looks as follows

```php
// Decoding
$data = FlexiblePolyline::decode('BlBoz5xJ67i1BU1B7PUzIhaUxL7YU');
/** $data:
[
    'precision' => 5,
    'thirdDim' => 2,
    'thirdDimPrecision' => 0,
    'polyline' => [
        [50.10228, 8.69821, 10],
        [50.10201, 8.69567, 20],
        [50.10063, 8.6915, 30],
        [50.09878, 8.68752, 40]
    ]
]
*/

// Encoding
$encoded = FlexiblePolyline::encode([
    [50.10228, 8.69821, 10],
    [50.10201, 8.69567, 20],
    [50.10063, 8.6915, 30],
    [50.09878, 8.68752, 40]
], 5, 2, 0);
/* $encoded: BlBoz5xJ67i1BU1B7PUzIhaUxL7YU */

// Third dimension
$thirdDimension = FlexiblePolyline::getThirdDimension('BVoz5xJ67i1BU')
/* $thirdDimension:1 */
```
