### PR TITLE
Dramatically optimize decoding step

### DIFF
--- a/dart/lib/converter.dart
+++ b/dart/lib/converter.dart
@@ -48,9 +48,9 @@ class Converter {
 
   // Decode single coordinate (say lat|lng|z) starting at index
   // Returns decoded coordinate, new index in tuple
-  Tuple2<double, int> decodeValue(String encoded, int index) {
+  Tuple2<double, int> decodeValue(List<String> encoded, int index) {
     final Tuple2<int, int> result =
-        decodeUnsignedVarint(encoded.split(''), index);
+        decodeUnsignedVarint(encoded, index);
     double coordinate = 0;
     int delta = result.item1;
     if ((delta & 1) != 0) {

--- a/dart/test/polyline_test.dart
+++ b/dart/test/polyline_test.dart
@@ -93,18 +93,18 @@ void main() {
   });
 
   test('testThirdDimension', () {
-    expect(FlexiblePolyline.getThirdDimension("BFoz5xJ67i1BU"),
+    expect(FlexiblePolyline.getThirdDimension("BFoz5xJ67i1BU".split('')),
         equals(ThirdDimension.ABSENT));
-    expect(FlexiblePolyline.getThirdDimension("BVoz5xJ67i1BU"),
+    expect(FlexiblePolyline.getThirdDimension("BVoz5xJ67i1BU".split('')),
         equals(ThirdDimension.LEVEL));
-    expect(FlexiblePolyline.getThirdDimension("BlBoz5xJ67i1BU"),
+    expect(FlexiblePolyline.getThirdDimension("BlBoz5xJ67i1BU".split('')),
         equals(ThirdDimension.ALTITUDE));
-    expect(FlexiblePolyline.getThirdDimension("B1Boz5xJ67i1BU"),
+    expect(FlexiblePolyline.getThirdDimension("B1Boz5xJ67i1BU".split('')),
         equals(ThirdDimension.ELEVATION));
   });
 
   test('testDecodeConvertValue', () {
-    String encoded = "h_wqiB";
+    final encoded = "h_wqiB".split('');
     double expected = -179.98321;
     Converter conv = new Converter(5);
     Tuple2<double, int> result = conv.decodeValue(encoded, 0);
@@ -251,6 +251,7 @@ void main() {
       bool hasThirdDimension = false;
       ThirdDimension expectedDimension = ThirdDimension.ABSENT;
       String encodedLine = encoded[i].trim();
+      final splittedLine = encodedLine.split('');
       String decodedLine = decoded[i].trim();
 
       //File parsing
@@ -269,7 +270,7 @@ void main() {
 
       //Validate thirdDimension
       ThirdDimension computedDimension =
-          FlexiblePolyline.getThirdDimension(encodedLine);
+          FlexiblePolyline.getThirdDimension(splittedLine);
       expect(computedDimension, expectedDimension);
 
       //Validate LatLngZ


### PR DESCRIPTION
The encoded String should not be split at every decode step:
instead, create a splitted version of the encoded polyline
and re-use it at every decode step.

### Performance gain
Before, a flex polyline with 28002 chars took 4571 ms.
After, a flex polyline with 28002 chars took 3 ms.