### PR TITLE
index.js: Removed declared constant without use

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,12 @@
-# Introduction
+# Contributing to the Flexible Polyline Project
+
+## Introduction
 
 The team behind the [Flexible Polyline](https://github.com/heremaps/flexible-polyline) gratefully accepts contributions via
 [pull requests](https://help.github.com/articles/about-pull-requests/) filed against the
 [GitHub project](https://github.com/heremaps/flexible-polyline/pulls).
 
-# Signing each Commit
+## Signing each Commit
 
 As part of filing a pull request we ask you to sign off the
 [Developer Certificate of Origin](https://developercertificate.org/) (DCO) in each commit.
@@ -17,12 +19,14 @@ to indicate that you agree with the DCO.
 
 An example signed commit message:
 
-```
-    README.md: Fix minor spelling mistake
+```txt
+README.md: Fix minor spelling mistake
 
-    Signed-off-by: John Doe <john.doe@example.com>
+Signed-off-by: John Doe <john.doe@example.com>
 ```
 
 Git has the `-s` flag that can sign a commit for you, see example below:
 
-`$ git commit -s -m 'README.md: Fix minor spelling mistake'`
+```sh
+git commit -s -m 'README.md: Fix minor spelling mistake'
+```

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -22,8 +22,6 @@ const LEVEL = 1;
 const ALTITUDE = 2;
 const ELEVATION = 3;
 // Reserved values 4 and 5 should not be selectable
-const CUSTOM1 = 6;
-const CUSTOM2 = 7;
 
 const Num = typeof BigInt !== "undefined" ? BigInt : Number;
 
@@ -195,7 +193,6 @@ function encodeScaledValue(value) {
 module.exports = {
     encode,
     decode,
-
     ABSENT,
     LEVEL,
     ALTITUDE,

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/flexpolyline",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Flexible Polyline encoding: a lossy compressed representation of a list of coordinate pairs or triples",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Removed the following constant that were not in use.

```js
const CUSTOM1 = 6;
const CUSTOM2 = 7;
```

---

- Updated CONTRIBUTING.md code blocks with their corresponding language fixing [MD040](https://github.com/DavidAnson/markdownlint/blob/v0.31.1/doc/md025.md)
- Added '#' & '##' titles fixing [MD025](https://github.com/DavidAnson/markdownlint/blob/v0.31.1/doc/md040.md)
