### PR TITLE
Python: Fix iter_dict_decode

### DIFF
--- a/python/flexpolyline/__init__.py
+++ b/python/flexpolyline/__init__.py
@@ -29,13 +29,15 @@ def decode(encoded):
 def iter_dict_decode(encoded):
     """Return an iterator over coordinates dicts. The dict contains always the keys 'lat', 'lng' and
     depending on the polyline can contain a third key ('elv', 'lvl', 'alt', ...)."""
-    third_dim_key = THIRD_DIM_MAP[get_third_dimension(encoded)]
+    third_dim_key = THIRD_DIM_MAP.get(get_third_dimension(encoded))
     for row in iter_decode(encoded):
-        yield {
+        coordinate = {
             'lat': row[0],
             'lng': row[1],
-            third_dim_key: row[2]
         }
+        if third_dim_key is not None:
+            coordinate[third_dim_key] = row[2]
+        yield coordinate
 
 
 def dict_decode(encoded):

--- a/python/test_flexpolyline.py
+++ b/python/test_flexpolyline.py
@@ -91,7 +91,17 @@ class TestFlexPolyline(unittest.TestCase):
         with self.assertRaises(ValueError):
             list(fp.iter_decode("CFoz5xJ67i1B1B7PzIhaxL7"))
 
-    def test_dict_decode(self):
+    def test_dict_decode_2d(self):
+        polyline = fp.dict_decode("BFoz5xJ67i1B1B7PzIhaxL7Y")
+        expected = [
+            {'lat': 50.10228, 'lng': 8.69821},
+            {'lat': 50.10201, 'lng': 8.69567},
+            {'lat': 50.10063, 'lng': 8.69150},
+            {'lat': 50.09878, 'lng': 8.68752}
+        ]
+        self.assertAlmostEqualDictSequence(polyline, expected, places=7)
+
+    def test_dict_decode_3d(self):
         polyline = fp.dict_decode("BlBoz5xJ67i1BU1B7PUzIhaUxL7YU")
         expected = [
             {'lat': 50.10228, 'lng': 8.69821, 'alt': 10},


### PR DESCRIPTION
The function was broken in case of a 2d polyline
Fixes issue https://github.com/heremaps/flexible-polyline/issues/62