### PR TITLE
Python: add "reserved"-types to 3rd-dimension-table

### DIFF
--- a/python/flexpolyline/encoding.py
+++ b/python/flexpolyline/encoding.py
@@ -16,11 +16,20 @@ ABSENT = 0
 LEVEL = 1
 ALTITUDE = 2
 ELEVATION = 3
-# Reserved values 4 and 5 should not be selectable
+RESERVED1 = 4  # Reserved for future types
+RESERVED2 = 5  # Reserved for future types
 CUSTOM1 = 6
 CUSTOM2 = 7
 
-THIRD_DIM_MAP = {ALTITUDE: 'alt', ELEVATION: 'elv', LEVEL: 'lvl', CUSTOM1: 'cst1', CUSTOM2: 'cst2'}
+THIRD_DIM_MAP = {
+    ALTITUDE: 'alt',
+    ELEVATION: 'elv',
+    LEVEL: 'lvl',
+    RESERVED1: 'rsv1',
+    RESERVED2: 'rsv2',
+    CUSTOM1: 'cst1',
+    CUSTOM2: 'cst2',
+}
 
 PolylineHeader = namedtuple('PolylineHeader', 'precision,third_dim,third_dim_precision')
 


### PR DESCRIPTION
Addresses issue
https://github.com/heremaps/flexible-polyline/issues/63

Eventhough reserved types 4 and 5 should not be used dict_decode can now correctly handle such encoded strings.