### PR TITLE
javascript: Add simple CLI

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -37,6 +37,20 @@ const decoded = decode(flexPolyline);
 console.log(decoded.polyline);
 ```
 
+### CLI
+
+The package comes with a simple CLI to encode / decode flexible polylines.
+
+Example usage:
+
+```sh
+# to encode:
+echo '[[50.1022829, 8.6982122],[50.1020076, 8.6956695],[50.1006313, 8.6914960],[50.0987800, 8.6875156]]' | npx @here/flexpolyline
+
+# to decode:
+echo -n 'BFoz5xJ67i1B1B7PzIhaxL7Y' | npx @here/flexpolyline decode
+```
+
 ## License
 
 Copyright (C) 2024 HERE Europe B.V.

--- a/javascript/cli.js
+++ b/javascript/cli.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (C) 2024 HERE Europe B.V.
+ * Licensed under MIT, see full license in LICENSE
+ * SPDX-License-Identifier: MIT
+ * License-Filename: LICENSE
+ */
+
+const fs = require('fs');
+const { encode, decode } = require('./index');
+
+const param = process.argv[2];
+
+if (param?.includes('help')) {
+    console.log('Usage:', process.argv[0], process.argv[1], '[OPTION]');
+    console.log();
+    console.log('Encodes or decodes flexible polylines from stdin to stdout')
+    console.log();
+    console.log('Options:');
+    console.log('    decode: Decode the input polyline. Default is to encode');
+    console.log('    --help: Display this help message');
+    console.log();
+    console.log('Input:');
+    console.log('    encoding: The input is either a JSON array of coordinates or a JSON object that can be passed directly to the "encode" function');
+    console.log('    decoding: The input is a string of an encoded polyline');
+    process.exit(0);
+}
+
+const isDecoding = param === 'decode';
+
+try {
+    if (isDecoding) {
+        const input = fs.readFileSync(0, 'utf-8').trim();
+        const decoded = decode(input);
+        process.stdout.write(JSON.stringify(decoded.polyline));
+        process.stdout.write('\n');
+    } else {
+        const input = JSON.parse(fs.readFileSync(0, 'utf-8'));
+        const encoded = encode(Array.isArray(input) ? { polyline: input } : input);
+        process.stdout.write(encoded);
+        process.stdout.write('\n');
+    }
+} catch (e) {
+    console.error(e);
+    process.exit(1);
+}

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,6 +4,7 @@
   "description": "Flexible Polyline encoding: a lossy compressed representation of a list of coordinate pairs or triples",
   "main": "index.js",
   "types": "index.d.ts",
+  "bin": "./cli.js",
   "scripts": {
     "prepack": "cp ../LICENSE .",
     "test": "node test/test.js",


### PR DESCRIPTION
Allows us to conveniently encode/decode flex polylines on command line by using "npx"